### PR TITLE
hoist transactions out of the migrate library

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -4,7 +4,8 @@ import (
 	"context"
 
 	"github.com/livebud/cli"
-	"github.com/matthewmueller/migrate"
+	"github.com/matthewmueller/migrate/internal/txmigrate"
+	// "github.com/matthewmueller/migrate"
 )
 
 type down struct {
@@ -38,9 +39,9 @@ func (c *CLI) Down(ctx context.Context, in *down) error {
 	// be a bit extra careful here
 	switch {
 	case in.N == nil:
-		return migrate.Down(log, db, fsys, c.tableName)
+		return txmigrate.Down(log, db, fsys, c.tableName)
 	case *in.N > 0:
-		return migrate.DownBy(log, db, fsys, c.tableName, *in.N)
+		return txmigrate.DownBy(log, db, fsys, c.tableName, *in.N)
 	}
 	return nil
 }

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/livebud/cli"
 	"github.com/matthewmueller/migrate/internal/txmigrate"
-	// "github.com/matthewmueller/migrate"
 )
 
 type down struct {

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/livebud/cli"
 	"github.com/matthewmueller/migrate"
+	"github.com/matthewmueller/migrate/internal/txmigrate"
 )
 
 type info struct {
@@ -41,7 +42,7 @@ func (c *CLI) Info(ctx context.Context, in *info) error {
 		return err
 	}
 
-	remote, err := migrate.RemoteVersion(db, fsys, c.tableName)
+	remote, err := txmigrate.RemoteVersion(db, fsys, c.tableName)
 	if err == migrate.ErrNoMigrations {
 		return errors.New("no remote migrations yet")
 	} else if err != nil {

--- a/internal/cli/redo.go
+++ b/internal/cli/redo.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/livebud/cli"
-	"github.com/matthewmueller/migrate"
+	"github.com/matthewmueller/migrate/internal/txmigrate"
 )
 
 type redo struct {
@@ -33,5 +33,5 @@ func (c *CLI) Redo(ctx context.Context, in *redo) error {
 		return err
 	}
 
-	return migrate.Redo(log, db, fsys, c.tableName)
+	return txmigrate.Redo(log, db, fsys, c.tableName)
 }

--- a/internal/cli/reset.go
+++ b/internal/cli/reset.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/livebud/cli"
-	"github.com/matthewmueller/migrate"
+	"github.com/matthewmueller/migrate/internal/txmigrate"
 )
 
 type reset struct {
@@ -33,11 +33,5 @@ func (c *CLI) Reset(ctx context.Context, in *reset) (err error) {
 		return err
 	}
 
-	if err := migrate.Down(log, db, fsys, c.tableName); err != nil {
-		return err
-	}
-	if err := migrate.Up(log, db, fsys, c.tableName); err != nil {
-		return err
-	}
-	return nil
+	return txmigrate.Reset(log, db, fsys, c.tableName)
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/livebud/cli"
-	"github.com/matthewmueller/migrate"
+	"github.com/matthewmueller/migrate/internal/txmigrate"
 )
 
 type up struct {
@@ -38,9 +38,9 @@ func (c *CLI) Up(ctx context.Context, in *up) error {
 	// be a bit extra careful here
 	switch {
 	case in.N == nil:
-		return migrate.Up(log, db, fsys, c.tableName)
+		return txmigrate.Up(log, db, fsys, c.tableName)
 	case *in.N > 0:
-		return migrate.UpBy(log, db, fsys, c.tableName, *in.N)
+		return txmigrate.UpBy(log, db, fsys, c.tableName, *in.N)
 	}
 
 	return nil

--- a/internal/txmigrate/txmigrate.go
+++ b/internal/txmigrate/txmigrate.go
@@ -1,0 +1,102 @@
+package txmigrate
+
+import (
+	"database/sql"
+	"io/fs"
+	"log/slog"
+
+	"github.com/matthewmueller/migrate"
+)
+
+func Up(_ *slog.Logger, db *sql.DB, fsys fs.FS, table string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	err = migrate.Up(nil, tx, fsys, table)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+func UpBy(_ *slog.Logger, db *sql.DB, fsys fs.FS, table string, i int) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	err = migrate.UpBy(nil, tx, fsys, table, i)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+func Down(_ *slog.Logger, db *sql.DB, fsys fs.FS, table string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	err = migrate.Down(nil, tx, fsys, table)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+func DownBy(_ *slog.Logger, db *sql.DB, fsys fs.FS, table string, i int) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	err = migrate.DownBy(nil, tx, fsys, table, i)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+func Redo(_ *slog.Logger, db *sql.DB, fsys fs.FS, table string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	err = migrate.Redo(nil, tx, fsys, table)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+func Reset(_ *slog.Logger, db *sql.DB, fsys fs.FS, table string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	err = migrate.Reset(nil, tx, fsys, table)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+func RemoteVersion(db *sql.DB, fsys fs.FS, table string) (string, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return "", err
+	}
+	name, err := migrate.RemoteVersion(tx, fsys, table)
+	if err != nil {
+		tx.Rollback()
+		return "", err
+	} else if err := tx.Commit(); err != nil {
+		return "", err
+	}
+	return name, nil
+}

--- a/migrate.go
+++ b/migrate.go
@@ -382,9 +382,13 @@ func getDirection(filename string) (Direction, error) {
 	return "", errors.New("filepath must specify the direction up or down (e.g. 000_setup.up.sql)")
 }
 
+func quote(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
 // ensure the table exists
 func ensureTableExists(db DB, tableName string) error {
-	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version bigint not null primary key);"); err != nil {
+	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS " + quote(tableName) + " (version bigint not null primary key);"); err != nil {
 		return err
 	}
 	return nil
@@ -392,7 +396,7 @@ func ensureTableExists(db DB, tableName string) error {
 
 // Version gets the version from postgres
 func getRemoteVersion(db DB, tableName string) (version uint, err error) {
-	err = db.QueryRow("SELECT version FROM " + tableName + " ORDER BY version DESC LIMIT 1").Scan(&version)
+	err = db.QueryRow("SELECT version FROM " + quote(tableName) + " ORDER BY version DESC LIMIT 1").Scan(&version)
 	switch {
 	case err == sql.ErrNoRows:
 		return 0, nil
@@ -405,7 +409,7 @@ func getRemoteVersion(db DB, tableName string) (version uint, err error) {
 
 // insert a new version into the table
 func insertVersion(db DB, tableName string, version uint) error {
-	if _, err := db.Exec("INSERT INTO "+tableName+" (version) VALUES ($1)", version); err != nil {
+	if _, err := db.Exec("INSERT INTO "+quote(tableName)+" (version) VALUES ($1)", version); err != nil {
 		return err
 	}
 	return nil
@@ -413,7 +417,7 @@ func insertVersion(db DB, tableName string, version uint) error {
 
 // delete a version from the table
 func deleteVersion(db DB, tableName string, version uint) error {
-	if _, err := db.Exec("DELETE FROM "+tableName+" WHERE version=$1", version); err != nil {
+	if _, err := db.Exec("DELETE FROM "+quote(tableName)+" WHERE version=$1", version); err != nil {
 		return err
 	}
 	return nil

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matryer/is"
 	"github.com/matthewmueller/migrate"
 	"github.com/matthewmueller/migrate/internal/db"
+	"github.com/matthewmueller/migrate/internal/txmigrate"
 	"github.com/matthewmueller/virt"
 
 	// sqlite db
@@ -112,7 +113,7 @@ var tests = []struct {
 			fs := fstest.MapFS{}
 			db, close := connect(t, url)
 			defer close()
-			err := migrate.Up(nil, db, fs, tableName)
+			err := txmigrate.Up(nil, db, fs, tableName)
 			is.Equal(migrate.ErrNoMigrations, err)
 		},
 	},
@@ -127,7 +128,7 @@ var tests = []struct {
 			}
 			db, close := connect(t, url)
 			defer close()
-			err := migrate.Up(nil, db, fs, tableName)
+			err := txmigrate.Up(nil, db, fs, tableName)
 			is.Equal(migrate.ErrNoMigrations, err)
 		},
 	},
@@ -139,7 +140,7 @@ var tests = []struct {
 			fs := fstest.MapFS{}
 			db, close := connect(t, url)
 			defer close()
-			err := migrate.Down(nil, db, fs, tableName)
+			err := txmigrate.Down(nil, db, fs, tableName)
 			is.Equal(migrate.ErrNoMigrations, err)
 		},
 	},
@@ -154,7 +155,7 @@ var tests = []struct {
 			}
 			db, close := connect(t, url)
 			defer close()
-			err := migrate.Down(nil, db, fs, tableName)
+			err := txmigrate.Down(nil, db, fs, tableName)
 			is.Equal(migrate.ErrNoMigrations, err)
 		},
 	},
@@ -187,7 +188,7 @@ var tests = []struct {
 			}
 			db, close := connect(t, url)
 			defer close()
-			err := migrate.Up(nil, db, fs, tableName)
+			err := txmigrate.Up(nil, db, fs, tableName)
 			is.Equal(migrate.ErrZerothMigration, err)
 		},
 	},
@@ -223,7 +224,7 @@ var tests = []struct {
 			db, close := connect(t, url)
 			defer close()
 
-			err := migrate.Up(nil, db, fs, tableName)
+			err := txmigrate.Up(nil, db, fs, tableName)
 			is.NoErr(err)
 
 			rows, err := db.Query(`insert into teams (id, name) values (1, 'jack') returning *`)
@@ -238,7 +239,7 @@ var tests = []struct {
 			}
 			is.NoErr(rows.Err())
 
-			err = migrate.Down(nil, db, fs, tableName)
+			err = txmigrate.Down(nil, db, fs, tableName)
 			is.NoErr(err)
 
 			_, err = db.Query(`insert into teams (id, name) values (2, 'jack') returning *`)
@@ -279,7 +280,7 @@ var tests = []struct {
 			db, close := connect(t, url)
 			defer close()
 
-			err := migrate.Up(nil, db, fs, tableName)
+			err := txmigrate.Up(nil, db, fs, tableName)
 			is.NoErr(err)
 
 			rows, err := db.Query(`insert into teams (id, name) values (1, 'jack') returning *`)
@@ -294,7 +295,7 @@ var tests = []struct {
 			}
 			is.NoErr(rows.Err())
 
-			err = migrate.Down(nil, db, fs, tableName)
+			err = txmigrate.Down(nil, db, fs, tableName)
 			is.NoErr(err)
 
 			_, err = db.Query(`insert into teams (id, name) values (2, 'jack') returning *`)
@@ -341,9 +342,9 @@ var tests = []struct {
 			db, close := connect(t, url)
 			defer close()
 
-			err := migrate.Up(nil, db, fs, tableName)
+			err := txmigrate.Up(nil, db, fs, tableName)
 			is.NoErr(err)
-			err = migrate.Up(nil, db, fs, tableName)
+			err = txmigrate.Up(nil, db, fs, tableName)
 			is.NoErr(err)
 
 			rows, err := db.Query(`insert into users (id, email) values (1, 'jack') returning *`)
@@ -358,9 +359,9 @@ var tests = []struct {
 			}
 			is.NoErr(rows.Err())
 
-			err = migrate.Down(nil, db, fs, tableName)
+			err = txmigrate.Down(nil, db, fs, tableName)
 			is.NoErr(err)
-			err = migrate.Down(nil, db, fs, tableName)
+			err = txmigrate.Down(nil, db, fs, tableName)
 			is.NoErr(err)
 
 			_, err = db.Query(`insert into users (id, email) values (2, 'jack') returning *`)
@@ -407,7 +408,7 @@ var tests = []struct {
 			db, close := connect(t, url)
 			defer close()
 
-			err := migrate.UpBy(nil, db, fs, tableName, 1)
+			err := txmigrate.UpBy(nil, db, fs, tableName, 1)
 			is.NoErr(err)
 
 			_, err = db.Query(`insert into teams (name) values ('jack') returning *`)
@@ -417,14 +418,14 @@ var tests = []struct {
 			is.True(strings.Contains(err.Error(), "users"))
 			is.True(notExists(err, "users"))
 
-			err = migrate.UpBy(nil, db, fs, tableName, 1)
+			err = txmigrate.UpBy(nil, db, fs, tableName, 1)
 			is.NoErr(err)
 			_, err = db.Query(`insert into teams (name) values ('jack') returning *`)
 			is.NoErr(err)
 			_, err = db.Query(`insert into users (email) values ('jack') returning *`)
 			is.NoErr(err)
 
-			err = migrate.UpBy(nil, db, fs, tableName, 1)
+			err = txmigrate.UpBy(nil, db, fs, tableName, 1)
 			is.NoErr(err)
 			is.NoErr(err)
 			_, err = db.Query(`insert into teams (name) values ('jack') returning *`)
@@ -432,7 +433,7 @@ var tests = []struct {
 			_, err = db.Query(`insert into users (email) values ('jack') returning *`)
 			is.NoErr(err)
 
-			err = migrate.DownBy(nil, db, fs, tableName, 1)
+			err = txmigrate.DownBy(nil, db, fs, tableName, 1)
 			is.NoErr(err)
 			_, err = db.Query(`insert into teams (name) values ('jack') returning *`)
 			is.NoErr(err)
@@ -441,7 +442,7 @@ var tests = []struct {
 			is.True(strings.Contains(err.Error(), "users"))
 			is.True(notExists(err, "users"))
 
-			err = migrate.DownBy(nil, db, fs, tableName, 1)
+			err = txmigrate.DownBy(nil, db, fs, tableName, 1)
 			is.NoErr(err)
 			_, err = db.Query(`insert into teams (name) values ('jack') returning *`)
 			is.True(strings.Contains(err.Error(), "teams"))
@@ -450,7 +451,7 @@ var tests = []struct {
 			is.True(strings.Contains(err.Error(), "users"))
 			is.True(notExists(err, "users"))
 
-			err = migrate.DownBy(nil, db, fs, tableName, 1)
+			err = txmigrate.DownBy(nil, db, fs, tableName, 1)
 			is.NoErr(err)
 			_, err = db.Query(`insert into teams (name) values ('jack') returning *`)
 			is.True(strings.Contains(err.Error(), "teams"))
@@ -498,7 +499,7 @@ var tests = []struct {
 			db, close := connect(t, url)
 			defer close()
 
-			err := migrate.UpBy(nil, db, fs, tableName, 1)
+			err := txmigrate.UpBy(nil, db, fs, tableName, 1)
 			is.NoErr(err)
 
 			_, err = db.Query(`insert into teams (name) values ('jack') returning *`)
@@ -508,7 +509,7 @@ var tests = []struct {
 			is.True(strings.Contains(err.Error(), "users"))
 			is.True(notExists(err, "users"))
 
-			err = migrate.UpBy(nil, db, fs, tableName, 1)
+			err = txmigrate.UpBy(nil, db, fs, tableName, 1)
 			is.True(err != nil)
 			is.True(syntaxError(err, "email"))
 
@@ -558,10 +559,10 @@ var tests = []struct {
 			defer close()
 
 			// setup
-			err := migrate.Up(nil, db, fs, tableName)
+			err := txmigrate.Up(nil, db, fs, tableName)
 			is.NoErr(err)
 
-			err = migrate.DownBy(nil, db, fs, tableName, 1)
+			err = txmigrate.DownBy(nil, db, fs, tableName, 1)
 			is.NoErr(err)
 			_, err = db.Query(`insert into teams (name) values ('jack') returning *`)
 			is.NoErr(err)
@@ -570,7 +571,7 @@ var tests = []struct {
 			is.True(strings.Contains(err.Error(), "users"))
 			is.True(notExists(err, "users"))
 
-			err = migrate.DownBy(nil, db, fs, tableName, 1)
+			err = txmigrate.DownBy(nil, db, fs, tableName, 1)
 			is.True(err != nil)
 			is.True(syntaxError(err, "exis"))
 
@@ -647,18 +648,18 @@ var tests = []struct {
 			defer close()
 
 			// setup
-			err := migrate.Up(nil, db, fs, tableName)
+			err := txmigrate.Up(nil, db, fs, tableName)
 			is.NoErr(err)
 
-			name, err := migrate.RemoteVersion(db, fs, tableName)
+			name, err := txmigrate.RemoteVersion(db, fs, tableName)
 			is.NoErr(err)
 			is.Equal(`002_users.up.sql`, name)
 
 			// teardown
-			err = migrate.Down(nil, db, fs, tableName)
+			err = txmigrate.Down(nil, db, fs, tableName)
 			is.NoErr(err)
 
-			_, err = migrate.RemoteVersion(db, fs, tableName)
+			_, err = txmigrate.RemoteVersion(db, fs, tableName)
 			is.Equal(migrate.ErrNoMigrations, err)
 		},
 	},
@@ -740,7 +741,7 @@ var tests = []struct {
 			db, close := connect(t, url)
 			defer close()
 
-			is.NoErr(migrate.Up(nil, db, fs, "migrate"))
+			is.NoErr(txmigrate.Up(nil, db, fs, "migrate"))
 
 			rows, err := db.Query(`insert into users (id, email) values (1, 'jack@standupjack.com') returning *`)
 			is.NoErr(err)
@@ -768,7 +769,7 @@ var tests = []struct {
 			is.NoErr(rows.Close())
 			is.Equal(0, count)
 
-			name, err := migrate.RemoteVersion(db, fs, tableName)
+			name, err := txmigrate.RemoteVersion(db, fs, tableName)
 			is.NoErr(err)
 			is.Equal(`002_users.up.sql`, name)
 		},
@@ -811,7 +812,7 @@ var tests = []struct {
 			db, close := connect(t, url)
 			defer close()
 
-			is.NoErr(migrate.Up(nil, db, fs, "migrate"))
+			is.NoErr(txmigrate.Up(nil, db, fs, "migrate"))
 
 			rows, err := db.Query(`insert into users (id, email) values (1, 'jack@standupjack.com') returning *`)
 			is.NoErr(err)
@@ -836,7 +837,7 @@ var tests = []struct {
 				`),
 			}
 
-			err = migrate.Redo(nil, db, fs, "migrate")
+			err = txmigrate.Redo(nil, db, fs, "migrate")
 			is.True(err != nil)
 
 			rows, err = db.Query(`select * from users`)
@@ -849,7 +850,159 @@ var tests = []struct {
 			is.NoErr(rows.Close())
 			is.Equal(1, count)
 
-			name, err := migrate.RemoteVersion(db, fs, tableName)
+			name, err := txmigrate.RemoteVersion(db, fs, tableName)
+			is.NoErr(err)
+			is.Equal(`002_users.up.sql`, name)
+		},
+	},
+	{
+		name: "reset",
+		fn: func(t testing.TB, url string) {
+			drop(t, url)
+			is := is.New(t)
+
+			fs := fstest.MapFS{
+				"001_init.up.sql": {
+					Data: []byte(`
+						create table if not exists teams (
+							id serial primary key not null,
+							name text not null
+						);
+					`),
+				},
+				"001_init.down.sql": {
+					Data: []byte(`
+						drop table if exists teams;
+					`),
+				},
+				"002_users.up.sql": {
+					Data: []byte(`
+						create table if not exists users (
+							id serial primary key not null,
+							email text not null
+						);
+					`),
+				},
+				"002_users.down.sql": {
+					Data: []byte(`
+						drop table if exists users;
+					`),
+				},
+			}
+
+			db, close := connect(t, url)
+			defer close()
+
+			is.NoErr(txmigrate.Up(nil, db, fs, "migrate"))
+
+			rows, err := db.Query(`insert into users (id, email) values (1, 'jack@standupjack.com') returning *`)
+			is.NoErr(err)
+			for rows.Next() {
+				var id int
+				var email string
+				err := rows.Scan(&id, &email)
+				is.NoErr(err)
+				is.Equal(1, id)
+				is.Equal("jack@standupjack.com", email)
+			}
+			is.NoErr(rows.Err())
+			is.NoErr(rows.Close())
+
+			err = migrate.Reset(nil, db, fs, "migrate")
+			is.NoErr(err)
+
+			rows, err = db.Query(`select * from users`)
+			is.NoErr(err)
+			count := 0
+			for rows.Next() {
+				count++
+			}
+			is.NoErr(rows.Err())
+			is.NoErr(rows.Close())
+			is.Equal(0, count)
+
+			name, err := txmigrate.RemoteVersion(db, fs, tableName)
+			is.NoErr(err)
+			is.Equal(`002_users.up.sql`, name)
+		},
+	},
+	{
+		name: "reset failure rollback",
+		fn: func(t testing.TB, url string) {
+			drop(t, url)
+			is := is.New(t)
+
+			fs := fstest.MapFS{
+				"001_init.up.sql": {
+					Data: []byte(`
+						create table if not exists teams (
+							id serial primary key not null,
+							name text not null
+						);
+					`),
+				},
+				"001_init.down.sql": {
+					Data: []byte(`
+						drop table if exists teams;
+					`),
+				},
+				"002_users.up.sql": {
+					Data: []byte(`
+						create table if not exists users (
+							id serial primary key not null,
+							email text not null
+						);
+					`),
+				},
+				"002_users.down.sql": {
+					Data: []byte(`
+						drop table if exists users;
+					`),
+				},
+			}
+
+			db, close := connect(t, url)
+			defer close()
+
+			is.NoErr(txmigrate.Up(nil, db, fs, "migrate"))
+
+			rows, err := db.Query(`insert into users (id, email) values (1, 'jack@standupjack.com') returning *`)
+			is.NoErr(err)
+			for rows.Next() {
+				var id int
+				var email string
+				err := rows.Scan(&id, &email)
+				is.NoErr(err)
+				is.Equal(1, id)
+				is.Equal("jack@standupjack.com", email)
+			}
+			is.NoErr(rows.Err())
+			is.NoErr(rows.Close())
+
+			// make the up migration fail
+			fs["002_users.up.sql"] = &fstest.MapFile{
+				Data: []byte(`
+					create table if not exists users (
+						id serial primary key not null,
+						email text not null,
+					; -- syntax error
+				`),
+			}
+
+			err = txmigrate.Reset(nil, db, fs, "migrate")
+			is.True(err != nil)
+
+			rows, err = db.Query(`select * from users`)
+			is.NoErr(err)
+			count := 0
+			for rows.Next() {
+				count++
+			}
+			is.NoErr(rows.Err())
+			is.NoErr(rows.Close())
+			is.Equal(1, count)
+
+			name, err := txmigrate.RemoteVersion(db, fs, tableName)
 			is.NoErr(err)
 			is.Equal(`002_users.up.sql`, name)
 		},


### PR DESCRIPTION
Moves the transactions out of the migrate programmatic library.

This makes the caller responsible for starting a transaction outside of this library. See the CLI for an implementation of this.

The reason to do this is it allows us to take many different kinds of database